### PR TITLE
fixes after manual testing with new parser

### DIFF
--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionFactory.java
@@ -53,7 +53,7 @@ import java.util.Set;
  */
 public class ExpressionFactory extends BaseQueryNodeFactory<ExpressionConfig,
         BinaryExpressionNode> {
-    public static final String TYPE = "Expression";
+    public static final String TYPE = "Expression2";
 
     /**
      * Operand type, left right or condition.

--- a/core/src/main/java/net/opentsdb/query/processor/expressions2/BaseExpressionNumericIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions2/BaseExpressionNumericIterator.java
@@ -119,11 +119,11 @@ public abstract class BaseExpressionNumericIterator<T extends TimeSeriesDataType
 
         // We can now collect metadata from the expression.
         metadata = new Metadata();
-        final MetadataCollector collector = new MetadataCollector(metadata);
-        expression.accept(collector);
+//        final MetadataCollector collector = new MetadataCollector(metadata);
+//        expression.accept(collector);
 
         // Get all metric values and define them in context
-        for (String m : metadata.variablesUsed) {
+        for (String m : config.getSourcesAlias()) {
             if (!sources.containsKey(m)) continue; // TODO: does not have the metric
             TypedTimeSeriesIterator<?> iterator = sources.get(m).iterator(NumericArrayType.TYPE).get();
             TimeSeriesValue<NumericArrayType> value = (TimeSeriesValue<NumericArrayType>) iterator.next();
@@ -147,8 +147,4 @@ public abstract class BaseExpressionNumericIterator<T extends TimeSeriesDataType
         return hasMoreValues;
     }
 
-    @Override
-    public TypeToken<? extends TimeSeriesDataType> getType() {
-        return NumericType.TYPE;
-    }
 }

--- a/core/src/main/java/net/opentsdb/query/processor/expressions2/ExpressionConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions2/ExpressionConfig.java
@@ -4,6 +4,7 @@ package net.opentsdb.query.processor.expressions2;
 import java.util.*;
 import java.util.Map.Entry;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -80,6 +81,7 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
     /**
      * Parsed tree of expression after simplication
      */
+    @JsonIgnore
     private final ExpressionNode parseTree;
 
     /**
@@ -115,8 +117,11 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
         expression = builder.expression;
         final ExpressionParser parser = new ExpressionParser();
         ExpressionNode expressionTree = parser.parse(expression);
-        final Simplifier simplifier = new Simplifier();
-        parseTree = simplifier.simplify(expressionTree);
+
+        // TODO: more work with simplifier
+//        final Simplifier simplifier = new Simplifier();
+//        parseTree = simplifier.simplify(expressionTree);
+        parseTree = expressionTree;
 
 
         if (null == builder.sources_alias) {
@@ -157,6 +162,13 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
      */
     public ExpressionNode getParseTree() {
         return parseTree;
+    }
+
+    /**
+     * @return The list of alias of the needed sources
+     */
+    public List<String> getSourcesAlias() {
+        return sources_alias;
     }
 
     /**

--- a/core/src/main/java/net/opentsdb/query/processor/expressions2/ExpressionIteratorFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions2/ExpressionIteratorFactory.java
@@ -32,7 +32,7 @@ import net.opentsdb.query.processor.expressions2.nodes.ExpressionNode;
 public class ExpressionIteratorFactory extends BaseQueryNodeFactory<ExpressionConfig, ExpressionQueryNode> {
 
     // This type should be unique among other plugins
-    public static final String TYPE = "Expression2";
+    public static final String TYPE = "Expression";
 
     public ExpressionIteratorFactory() {
         super();
@@ -124,7 +124,7 @@ public class ExpressionIteratorFactory extends BaseQueryNodeFactory<ExpressionCo
 
     @Override
     public ExpressionConfig parseConfig(ObjectMapper mapper, TSDB tsdb, JsonNode node) {
-        return null;
+        return ExpressionConfig.parse(mapper, tsdb, node);
     }
 
     class NumericArrayIteratorFactory implements QueryIteratorFactory<ExpressionQueryNode, NumericArrayType> {

--- a/core/src/main/java/net/opentsdb/query/processor/expressions2/ExpressionNumericArrayIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions2/ExpressionNumericArrayIterator.java
@@ -1,6 +1,7 @@
 package net.opentsdb.query.processor.expressions2;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 import com.google.common.reflect.TypeToken;
@@ -10,6 +11,7 @@ import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.data.types.numeric.NumericArrayType;
+import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.processor.expressions2.ExpressionConfig;
 import net.opentsdb.query.processor.expressions.ExpressionResult;
@@ -39,20 +41,12 @@ public class ExpressionNumericArrayIterator
 
     @Override
     public TimeSeriesValue<? extends TimeSeriesDataType> next() {
-        // TODO
-
         if (value instanceof DoubleArrayValue) {
             DoubleArrayValue doubleArray = (DoubleArrayValue) value;
-            double_values = new double[doubleArray.getLength()];
-            for (int i = 0; i < double_values.length; i++) {
-                double_values[i] = doubleArray.getValueAt(i);
-            }
+            double_values = doubleArray.getValues();
         } else if (value instanceof LongArrayValue) {
             LongArrayValue longArray = (LongArrayValue) value;
-            long_values = new long[longArray.getLength()];
-            for (int i = 0; i < long_values.length; i++) {
-                long_values[i] = longArray.getValueAt(i);
-            }
+            long_values = longArray.getValues();
         }
         // TODO: result is not array
 
@@ -74,6 +68,11 @@ public class ExpressionNumericArrayIterator
 
     @Override
     public TypeToken<NumericArrayType> type() {
+        return NumericArrayType.TYPE;
+    }
+
+    @Override
+    public TypeToken<? extends TimeSeriesDataType> getType() {
         return NumericArrayType.TYPE;
     }
 

--- a/core/src/main/java/net/opentsdb/query/processor/expressions2/ExpressionQueryNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions2/ExpressionQueryNode.java
@@ -6,8 +6,7 @@ import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TypedTimeSeriesIterator;
 import net.opentsdb.data.types.numeric.NumericArrayType;
 import net.opentsdb.query.*;
-import net.opentsdb.query.processor.expressions.BinaryExpressionNode;
-import net.opentsdb.query.processor.expressions.BinaryExpressionNodeFactory;
+import net.opentsdb.query.joins.Joiner;
 import net.opentsdb.query.processor.expressions2.ExpressionConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +40,11 @@ public class ExpressionQueryNode extends AbstractQueryNode<ExpressionConfig> {
     protected final AtomicBoolean all_in;
 
     /**
+     * The joiner.
+     */
+    protected final Joiner joiner;
+
+    /**
      * Default c-tor.
      *
      * @param factory  The factory we came from.
@@ -62,14 +66,19 @@ public class ExpressionQueryNode extends AbstractQueryNode<ExpressionConfig> {
         // Store ids of all needed results as key
         // We need all these results to evaluate this query
         for (QueryResultId resultId : exprConf.getResultsNeeded()) {
-            // TODO: set a query result ID as key
             results.put(resultId, null);
         }
+
+        joiner = new Joiner(expression_config.getJoin());
     }
 
     @Override
     public ExpressionConfig config() {
         return expression_config;
+    }
+
+    public Joiner joiner() {
+        return joiner;
     }
 
     @Override
@@ -105,18 +114,6 @@ public class ExpressionQueryNode extends AbstractQueryNode<ExpressionConfig> {
 
             results.put(next.dataSource(), next);
         }
-
-//        // TODO: decide whether or not the logic is needed here
-//        // referring to onNext method in BinaryExpressionNode
-//        if (resolveMetrics(next)) {
-//            // resolving, don't progress yet.
-//            return;
-//        }
-//
-//        if (resolveJoinStrings(next)) {
-//            // resolving, don't progress yet.
-//            return;
-//        }
 
         // see if all the results are in.
         boolean full_map = true;

--- a/core/src/main/java/net/opentsdb/query/processor/expressions2/ExpressionResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions2/ExpressionResult.java
@@ -9,6 +9,7 @@ import net.opentsdb.data.TimeSpecification;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.QueryResultId;
+import net.opentsdb.query.joins.JoinConfig;
 import net.opentsdb.rollup.RollupConfig;
 
 import java.time.temporal.ChronoUnit;
@@ -59,7 +60,7 @@ public class ExpressionResult implements QueryResult {
 
         for (Map.Entry<QueryResultId, QueryResult> entry : node.results().entrySet()) {
             for (TimeSeries ts : entry.getValue().timeSeries()) {
-                builder.put(entry.getKey().nodeID(), ts);
+                builder.put(entry.getKey().dataSource(), ts);
                 break;
             }
         }

--- a/core/src/main/java/net/opentsdb/query/processor/expressions2/eval/DoubleArrayValue.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions2/eval/DoubleArrayValue.java
@@ -65,6 +65,10 @@ public class DoubleArrayValue extends NumericValue {
         return underlying[idx];
     }
 
+    public double[] getValues() {
+        return underlying;
+    }
+
     @Override
     public void close() {
         underlying = null;

--- a/core/src/main/java/net/opentsdb/query/processor/expressions2/eval/EvaluationContext.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions2/eval/EvaluationContext.java
@@ -71,7 +71,7 @@ public class EvaluationContext {
     public ExpressionValue lookup(final String metricName) {
         final ExpressionValue result = metrics.get(metricName);
         if (null == result) {
-            throw new ExpressionException("tried to look up an undefined metric name in EvaluationContext");
+            throw new ExpressionException("tried to look up an undefined metric name in EvaluationContext: " + metricName);
         }
         return result;
     }

--- a/core/src/main/java/net/opentsdb/query/processor/expressions2/eval/Evaluator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions2/eval/Evaluator.java
@@ -167,14 +167,12 @@ public class Evaluator extends DefaultExpressionVisitor {
 
     @Override
     public void leaveTernary(TernaryOperator s) {
-        final ExpressionValue falseCase = context.pop();
-        final ExpressionValue trueCase = context.pop();
         final ExpressionValue condition = context.pop();
 
         if (condition.equals(BooleanConstantValue.TRUE)) {
-            context.push(trueCase);
+            s.getTrueCase().accept(this);
         } else {
-            context.push(falseCase);
+            s.getFalseCase().accept(this);
         }
     }
 

--- a/core/src/main/java/net/opentsdb/query/processor/expressions2/eval/LongArrayValue.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions2/eval/LongArrayValue.java
@@ -51,6 +51,10 @@ public class LongArrayValue extends NumericValue {
         return underlying[idx];
     }
 
+    public long[] getValues() {
+        return underlying;
+    }
+
     @Override
     public void close() {
         underlying = null;

--- a/core/src/main/java/net/opentsdb/query/processor/expressions2/nodes/TernaryOperator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions2/nodes/TernaryOperator.java
@@ -27,8 +27,6 @@ public class TernaryOperator extends ExpressionOperator {
     public void accept(ExpressionVisitor visitor) {
         visitor.enterTernary(this);
         condition.accept(visitor);
-        trueCase.accept(visitor);
-        falseCase.accept(visitor);
         visitor.leaveTernary(this);
     }
 

--- a/core/src/test/java/net/opentsdb/query/processor/expressions2/TestExpressionIteratorFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions2/TestExpressionIteratorFactory.java
@@ -135,7 +135,7 @@ public class TestExpressionIteratorFactory {
         assertFalse(planner.graph().hasEdgeConnecting(SINK, planner.nodeForId("m1")));
 
         QueryNodeConfig b1 = planner.configNodeForId("expression");
-        assertEquals("Expression2", b1.getType());
+        assertEquals("Expression", b1.getType());
 
         assertTrue((b1 instanceof ExpressionConfig));
         ExpressionConfig p1 = (ExpressionConfig) b1;
@@ -216,7 +216,7 @@ public class TestExpressionIteratorFactory {
         assertFalse(planner.graph().hasEdgeConnecting(SINK, planner.nodeForId("m3")));
 
         QueryNodeConfig b1 = planner.configNodeForId("e1");
-        assertEquals("Expression2", b1.getType());
+        assertEquals("Expression", b1.getType());
 
         assertTrue((b1 instanceof ExpressionConfig));
         ExpressionConfig p1 = (ExpressionConfig) b1;
@@ -281,7 +281,7 @@ public class TestExpressionIteratorFactory {
         assertFalse(planner.graph().hasEdgeConnecting(planner.nodeForId("e1"), planner.nodeForId("m1")));
 
         QueryNodeConfig b1 = planner.configNodeForId("e1");
-        assertEquals("Expression2", b1.getType());
+        assertEquals("Expression", b1.getType());
 
         ExpressionConfig p1 = (ExpressionConfig) b1;
         assertEquals("e1", p1.getId());
@@ -364,7 +364,7 @@ public class TestExpressionIteratorFactory {
         assertTrue(planner.graph().hasEdgeConnecting(SINK, planner.nodeForId("e1")));
 
         QueryNodeConfig b1 = planner.configNodeForId("e1");
-        assertEquals("Expression2", b1.getType());
+        assertEquals("Expression", b1.getType());
         ExpressionConfig p1 = (ExpressionConfig) b1;
 
         assertEquals("e1", p1.getId());

--- a/core/src/test/java/net/opentsdb/query/processor/expressions2/TestExpressionResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions2/TestExpressionResult.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import static org.junit.Assert.*;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -97,6 +98,9 @@ public class TestExpressionResult extends BaseNumericTest {
         }};
         when(node.results()).thenReturn(results);
 
+        Joiner joiner = mock(Joiner.class);
+        when(node.joiner()).thenReturn(joiner);
+        when(joiner.joinIds(any(TimeSeries.class), any(TimeSeries.class), any(String.class), any(JoinConfig.JoinType.class))).thenReturn(null);
         result.join();
         assertEquals(1, result.time_series.size());
 


### PR DESCRIPTION
This version of OpenTSDB currently utilizes the new parser. To switch back to the original parser, modify `TYPE` in core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionFactory.java to "Expression", and `TYPE` in core/src/main/java/net/opentsdb/query/processor/expressions2/ExpressionIteratorFactory.java to anything other than "Expression", for example, "Expression2". The types work as ids for plugins, so they should be unique. 

A few notes for future works on the new parser (some from the previous PR):
1. mostly importantly more testing could be done. New additions for integrating the new parser have unit tests also created. I have also manually tested with queries by running opentsdb. However, the integration should also be tested by people with more knowledge of querying graph (that uses different and complex features, such as grouping, downsampling, etc.). 
2. Need to decide whether it's necessary to support expression iterators of `NumericSummaryType` (and possibly `NumericType`?)
3. Handle infectiousNan for evaluation operations other than divide and mod